### PR TITLE
[http_image_provider] Add support for ImageLoadingBuilder

### DIFF
--- a/http_image_provider/lib/consolidate_response.dart
+++ b/http_image_provider/lib/consolidate_response.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:http/http.dart';
+
+export 'dart:io' show HttpClientResponse;
+export 'dart:typed_data' show Uint8List;
+
+/// Signature for getting notified when chunks of bytes are received while
+/// consolidating the bytes of an [HttpClientResponse] into a [Uint8List].
+///
+/// The `cumulative` parameter will contain the total number of bytes received
+/// thus far. If the response has been gzipped, this number will be the number
+/// of compressed bytes that have been received _across the wire_.
+///
+/// The `total` parameter will contain the _expected_ total number of bytes to
+/// be received across the wire (extracted from the value of the
+/// `Content-Length` HTTP response header), or null if the size of the response
+/// body is not known in advance (this is common for HTTP chunked transfer
+/// encoding, which itself is common when a large amount of data is being
+/// returned to the client and the total size of the response may not be known
+/// until the request has been fully processed).
+///
+/// This is used in [consolidateHttpClientResponseBytes].
+typedef BytesReceivedCallback = void Function(int cumulative, int? total);
+
+/// Efficiently converts the response body of an [HttpClientResponse] into a
+/// [Uint8List].
+///
+/// The future returned will forward any error emitted by `response`.
+///
+/// The `onBytesReceived` callback, if specified, will be invoked for every
+/// chunk of bytes that is received while consolidating the response bytes.
+/// If the callback throws an error, processing of the response will halt, and
+/// the returned future will complete with the error that was thrown by the
+/// callback. For more information on how to interpret the parameters to the
+/// callback, see the documentation on [BytesReceivedCallback].
+Future<Uint8List> consolidateStreamedResponseBytes(
+  StreamedResponse response, {
+  BytesReceivedCallback? onBytesReceived,
+}) {
+  final Completer<Uint8List> completer = Completer<Uint8List>.sync();
+
+  final _OutputBuffer output = _OutputBuffer();
+  ByteConversionSink sink = output;
+  int? expectedContentLength = response.contentLength;
+  if (expectedContentLength == -1) {
+    expectedContentLength = null;
+  }
+
+  int bytesReceived = 0;
+  late final StreamSubscription<List<int>> subscription;
+  subscription = response.stream.listen((List<int> chunk) {
+    sink.add(chunk);
+    if (onBytesReceived != null) {
+      bytesReceived += chunk.length;
+      try {
+        onBytesReceived(bytesReceived, expectedContentLength);
+      } catch (error, stackTrace) {
+        completer.completeError(error, stackTrace);
+        subscription.cancel();
+        return;
+      }
+    }
+  }, onDone: () {
+    sink.close();
+    completer.complete(output.bytes);
+  }, onError: completer.completeError, cancelOnError: true);
+
+  return completer.future;
+}
+
+class _OutputBuffer extends ByteConversionSinkBase {
+  List<List<int>>? _chunks = <List<int>>[];
+  int _contentLength = 0;
+  Uint8List? _bytes;
+
+  @override
+  void add(List<int> chunk) {
+    assert(_bytes == null);
+    _chunks!.add(chunk);
+    _contentLength += chunk.length;
+  }
+
+  @override
+  void close() {
+    if (_bytes != null) {
+      // We've already been closed; this is a no-op
+      return;
+    }
+    _bytes = Uint8List(_contentLength);
+    int offset = 0;
+    for (final List<int> chunk in _chunks!) {
+      _bytes!.setRange(offset, offset + chunk.length, chunk);
+      offset += chunk.length;
+    }
+    _chunks = null;
+  }
+
+  Uint8List get bytes {
+    assert(_bytes != null);
+    return _bytes!;
+  }
+}

--- a/http_image_provider/lib/consolidate_response.dart
+++ b/http_image_provider/lib/consolidate_response.dart
@@ -1,15 +1,13 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:http/http.dart';
 
-export 'dart:io' show HttpClientResponse;
 export 'dart:typed_data' show Uint8List;
 
 /// Signature for getting notified when chunks of bytes are received while
-/// consolidating the bytes of an [HttpClientResponse] into a [Uint8List].
+/// consolidating the bytes of an [StreamedResponse] into a [Uint8List].
 ///
 /// The `cumulative` parameter will contain the total number of bytes received
 /// thus far. If the response has been gzipped, this number will be the number
@@ -23,10 +21,10 @@ export 'dart:typed_data' show Uint8List;
 /// returned to the client and the total size of the response may not be known
 /// until the request has been fully processed).
 ///
-/// This is used in [consolidateHttpClientResponseBytes].
+/// This is used in [consolidateStreamedResponseBytes].
 typedef BytesReceivedCallback = void Function(int cumulative, int? total);
 
-/// Efficiently converts the response body of an [HttpClientResponse] into a
+/// Efficiently converts the response body of an [StreamedResponse] into a
 /// [Uint8List].
 ///
 /// The future returned will forward any error emitted by `response`.

--- a/http_image_provider/lib/http_image_provider.dart
+++ b/http_image_provider/lib/http_image_provider.dart
@@ -1,7 +1,6 @@
 library http_image_provider;
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -94,7 +93,7 @@ class HttpImageProvider extends ImageProvider<HttpImageProvider> {
       }
       final response = await client.send(request);
 
-      if (response.statusCode != HttpStatus.ok) {
+      if (response.statusCode != 200) {
         // The network may be only temporarily unavailable, or the file will be
         // added on the server later. Avoid having future calls to resolve
         // fail to check the network again.

--- a/http_image_provider/test/consolidate_response_test.dart
+++ b/http_image_provider/test/consolidate_response_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:http_image_provider/consolidate_response.dart';
+
+final Uint8List chunkOne = Uint8List.fromList(<int>[0, 1, 2, 3, 4, 5]);
+final Uint8List chunkTwo = Uint8List.fromList(<int>[6, 7, 8, 9, 10]);
+
+void main() {
+  group(consolidateStreamedResponseBytes, () {
+    late MockStreamedResponse response;
+
+    setUp(() {
+      response = MockStreamedResponse(chunkOne: chunkOne, chunkTwo: chunkTwo);
+    });
+
+    test('Converts an StreamedResponse with contentLength to bytes', () async {
+      response.contentLength = chunkOne.length + chunkTwo.length;
+      final List<int> bytes = await consolidateStreamedResponseBytes(response);
+
+      expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    });
+
+    test('Converts a compressed StreamedResponse with contentLength to bytes',
+        () async {
+      response.contentLength = chunkOne.length;
+      final List<int> bytes = await consolidateStreamedResponseBytes(response);
+
+      expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    });
+
+    test('Converts an StreamedResponse without contentLength to bytes',
+        () async {
+      response.contentLength = -1;
+      final List<int> bytes = await consolidateStreamedResponseBytes(response);
+
+      expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    });
+
+    test('Notifies onBytesReceived for every chunk of bytes', () async {
+      final int syntheticTotal = (chunkOne.length + chunkTwo.length) * 2;
+      response.contentLength = syntheticTotal;
+      final List<int?> records = <int?>[];
+      await consolidateStreamedResponseBytes(
+        response,
+        onBytesReceived: (int cumulative, int? total) {
+          records.addAll(<int?>[cumulative, total]);
+        },
+      );
+
+      expect(records, <int>[
+        chunkOne.length,
+        syntheticTotal,
+        chunkOne.length + chunkTwo.length,
+        syntheticTotal,
+      ]);
+    });
+
+    test('forwards errors from StreamedResponse', () async {
+      response = MockStreamedResponse(error: Exception('Test Error'));
+      response.contentLength = -1;
+
+      expect(consolidateStreamedResponseBytes(response), throwsException);
+    });
+
+    test('Propagates error to Future return value if onBytesReceived throws',
+        () async {
+      response.contentLength = -1;
+      final Future<List<int>> result = consolidateStreamedResponseBytes(
+        response,
+        onBytesReceived: (int cumulative, int? total) {
+          throw 'misbehaving callback';
+        },
+      );
+
+      expect(result, throwsA(equals('misbehaving callback')));
+    });
+  });
+}
+
+class MockStreamedResponse extends Fake implements StreamedResponse {
+  MockStreamedResponse({
+    this.error,
+    this.chunkOne = const <int>[],
+    this.chunkTwo = const <int>[],
+  });
+
+  final dynamic error;
+  final List<int> chunkOne;
+  final List<int> chunkTwo;
+
+  @override
+  int contentLength = 0;
+
+  @override
+  ByteStream get stream {
+    if (error != null) {
+      return ByteStream(Stream<List<int>>.fromFuture(
+        Future<List<int>>.error(error as Object),
+      ));
+    }
+    return ByteStream(Stream<List<int>>.fromIterable(<List<int>>[
+      chunkOne,
+      chunkTwo,
+    ]));
+  }
+}


### PR DESCRIPTION
Docs: https://api.flutter.dev/flutter/widgets/Image/loadingBuilder.html
Issue: https://github.com/ueman/dart-packages/issues/5
Code copied form flutter repo and modifed to support Client instead of HttpClient: 
packages/flutter/lib/src/painting/_network_image_io.dart
packages/flutter/lib/src/foundation/consolidate_response.dart