### PR TITLE
Implement portrait orientation check for `dynamic_island_watermark` visibility

### DIFF
--- a/dynamic_island_watermark/lib/dynamic_island_watermark.dart
+++ b/dynamic_island_watermark/lib/dynamic_island_watermark.dart
@@ -100,6 +100,13 @@ class _IslandWatermarkState extends State<_IslandWatermark> {
 
     if (config == null) return SizedBox.shrink();
 
+    // Only show the watermark when the device is in portrait orientation.
+    // In landscape (or any other) orientations, the Dynamic Island placement
+    // does not make sense and can cause visual artifacts.
+    final isPortrait = _isPortrait();
+
+    if (!isPortrait) return SizedBox.shrink();
+
     return Positioned(
       top: config.top,
       height: config.height,
@@ -131,6 +138,22 @@ class _IslandWatermarkState extends State<_IslandWatermark> {
       'iPhone 14 Pro Max' => _DynamicIslandConfig.iPhone15ProMax,
       _ => null,
     };
+  }
+
+  bool _isPortrait() {
+    final mediaQuery = MediaQuery.maybeOf(context);
+    if (mediaQuery != null) {
+      return mediaQuery.orientation == Orientation.portrait;
+    }
+
+    final view = View.maybeOf(context);
+    if (view != null) {
+      final size = view.physicalSize;
+      return size.height >= size.width;
+    }
+
+    // Default to portrait if we cannot determine orientation safely.
+    return true;
   }
 }
 

--- a/dynamic_island_watermark/lib/dynamic_island_watermark.dart
+++ b/dynamic_island_watermark/lib/dynamic_island_watermark.dart
@@ -141,9 +141,9 @@ class _IslandWatermarkState extends State<_IslandWatermark> {
   }
 
   bool _isPortrait() {
-    final mediaQuery = MediaQuery.maybeOf(context);
-    if (mediaQuery != null) {
-      return mediaQuery.orientation == Orientation.portrait;
+    final orientation = MediaQuery.maybeOrientationOf(context);
+    if (orientation != null) {
+      return orientation == Orientation.portrait;
     }
 
     final view = View.maybeOf(context);
@@ -152,8 +152,8 @@ class _IslandWatermarkState extends State<_IslandWatermark> {
       return size.height >= size.width;
     }
 
-    // Default to portrait if we cannot determine orientation safely.
-    return true;
+    // Default to not showing when orientation cannot be determined.
+    return false;
   }
 }
 


### PR DESCRIPTION
### Hide Dynamic Island watermark in non‑portrait orientations (iOS)

Ensures the watermark is only shown in portrait mode to prevent visual artifacts when the device rotates to landscape or other orientations.

- **What changed**: Added an orientation check in `_IslandWatermarkState` to early-return when not portrait _(uses `MediaQuery` with a safe `View` fallback)_.
- **Why**: The watermark placement only makes sense in portrait; showing it in other orientations causes glitches.
- **Impact**: iOS-only behavior change; no API changes; Android/Web unaffected; preserves existing text direction and device model logic.

### Testing
- Launch the example on an iPhone with Dynamic Island.
- In portrait: watermark is visible and positioned correctly.
- Rotate to landscape _(and back)_: watermark hides in non-portrait; reappears in portrait.

> [!Note]
> This aims to fix the issue #9  